### PR TITLE
Add Netlify Next.js plugin to fix 404 deployment issues

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,5 +14,9 @@ NPM_CONFIG_AUDIT = "false"
 NPM_CONFIG_FUND = "false"
 NPM_CONFIG_PROGRESS = "false"
 
+# Enable Netlify's official Next.js runtime to serve App Router/SSR/API routes
+[[plugins]]
+package = "@netlify/plugin-nextjs"
+
 [[plugins]]
 package = "@netlify/plugin-lighthouse"


### PR DESCRIPTION
## Purpose
Fix 404 page errors occurring after deploying the Next.js website to a new Netlify account (https://nextabook.netlify.app/). The user was experiencing deployment issues when migrating from the previous Netlify deployment at https://nextaccounting2.netlify.app/.

## Code changes
- Added `@netlify/plugin-nextjs` plugin configuration to `netlify.toml`
- This enables Netlify's official Next.js runtime to properly serve App Router, SSR, and API routes
- Plugin is positioned before the existing Lighthouse plugin in the configurationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 122`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c90ea12132ba4828a30bf998376239d8/vortex-haven)

👀 [Preview Link](https://c90ea12132ba4828a30bf998376239d8-vortex-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c90ea12132ba4828a30bf998376239d8</projectId>-->
<!--<branchName>vortex-haven</branchName>-->